### PR TITLE
Change backup command to give back the error code

### DIFF
--- a/mongodb-backup-template.yaml
+++ b/mongodb-backup-template.yaml
@@ -48,7 +48,22 @@ objects:
                   command:
                     - 'bash'
                     - '-c'
-                    - 'ls -rdt /var/lib/mongodb-backup/dump-* | head -n -$MONGODB_BACKUP_KEEP | xargs rm -rf; DIR=/var/lib/mongodb-backup/dump-`date +%F-%T`; mongodump -j 1 -u admin -p $MONGODB_ADMIN_PASSWORD -h $MONGODB_SERVICE_HOST --port $MONGODB_SERVICE_PORT --authenticationDatabase=admin --gzip --out=$DIR; echo "Backup complete"; echo; echo "To restore, use:"; echo "~# mongorestore -u admin -p \$MONGODB_ADMIN_PASSWORD --authenticationDatabase admin --gzip $DIR/DB_TO_RESTORE -d DB_TO_RESTORE_INTO"; sleep 60'
+                    - >-
+                      ls -rdt /var/lib/mongodb-backup/dump-* |
+                      head -n -$MONGODB_BACKUP_KEEP |
+                      xargs rm -rf &&
+                      DIR=/var/lib/mongodb-backup/dump-`date +%F-%T` &&
+                      mongodump -j 1 -u admin -p $MONGODB_ADMIN_PASSWORD --host $MONGODB_SERVICE_HOST --port $MONGODB_SERVICE_PORT --authenticationDatabase=admin --gzip --out=$DIR &&
+                      echo &&
+                      echo "To restore, use:" &&
+                      echo "~# mongorestore -u admin -p \$MONGODB_ADMIN_PASSWORD --authenticationDatabase admin --gzip $DIR/DB_TO_RESTORE -d DB_TO_RESTORE_INTO"
+                  resources:
+                  limits:
+                    cpu: 250m
+                    memory: 1Gi
+                  requests:
+                    cpu: 100m
+                    memory: 512Mi
                   env:
                     - name: MONGODB_BACKUP_KEEP
                       value: ${MONGODB_BACKUP_KEEP}


### PR DESCRIPTION
The past command just executed step by step, but does not
giveback the final error code. This doesn't allow the monitoring
of the backup, which could lead to a incompleted backup showed as
completed. The print "Backup completed" has been removed, as well
as the 60 sec wait at the end.

Additionally bigger MongoDBs do have a higher ressource consumption
for the dump process and get OOM killed.