### PR TITLE
Add the service host and service port as a parameter to the template

### DIFF
--- a/mongodb-backup-template.yaml
+++ b/mongodb-backup-template.yaml
@@ -26,6 +26,10 @@ parameters:
     value: 'mongodb-backup'
   - name: MONGODB_ADMIN_PASSWORD
     description: 'MongoDB admin user''s password. Required.'
+  - name: MONGODB_SERVICE_HOST
+    description: 'MongoDB Host server to backup from.'
+  - name: MONGODB_SERVICE_PORT
+    description: 'Port from the host server where MongoDB is listening to.'
 objects:
   - apiVersion: batch/v2alpha1
     kind: ScheduledJob


### PR DESCRIPTION
When creating the job from a template, passing the mongodb receiving host with port was not parameterized. This should give the flexibility.